### PR TITLE
ID-6 – refine /v1/auth

### DIFF
--- a/src/Application/Actions/Login.php
+++ b/src/Application/Actions/Login.php
@@ -121,8 +121,11 @@ class Login extends Action
         // Throws on bad password.
         Password::verify($credentials->raw_password, $person);
 
+        $id = (string) $person->getId();
+
         return new JsonResponse([
-            'jwt' => Token::create((string) $person->getId(), true, $person->stripe_customer_id),
+            'id' => $id,
+            'jwt' => Token::create($id, true, $person->stripe_customer_id),
         ]);
     }
 }

--- a/src/Application/Middleware/CredentialsRecaptchaMiddleware.php
+++ b/src/Application/Middleware/CredentialsRecaptchaMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BigGive\Identity\Application\Middleware;
+
+use BigGive\Identity\Domain\Credentials;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CredentialsRecaptchaMiddleware extends RecaptchaMiddleware
+{
+    protected function getCode(ServerRequestInterface $request): string
+    {
+        $body = (string) $request->getBody();
+
+        /** @var Credentials $credentials */
+        $credentials = $this->serializer->deserialize(
+            $body,
+            Credentials::class,
+            'json'
+        );
+
+        return $credentials->captcha_code;
+    }
+}

--- a/src/Application/Middleware/PersonRecaptchaMiddleware.php
+++ b/src/Application/Middleware/PersonRecaptchaMiddleware.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BigGive\Identity\Application\Middleware;
+
+use BigGive\Identity\Domain\Person;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+
+class PersonRecaptchaMiddleware extends RecaptchaMiddleware
+{
+    protected function getCode(ServerRequestInterface $request): string
+    {
+        $body = (string) $request->getBody();
+
+        $captchaCode = '';
+
+        /** @var Person $person */
+        try {
+            $person = $this->serializer->deserialize(
+                $body,
+                Person::class,
+                'json'
+            );
+            $captchaCode = $person->captcha_code ?? '';
+        } catch (UnexpectedValueException $exception) { // This is the Serializer one, not the global one
+            // No-op. Allow verification with blank string to occur. This will fail with the live
+            // service, but can be mocked with success in unit tests so we can test handling of other
+            // code that might need to handle deserialise errors.
+        }
+
+        return $captchaCode;
+    }
+}

--- a/src/Domain/Credentials.php
+++ b/src/Domain/Credentials.php
@@ -18,6 +18,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Credentials implements JsonSerializable
 {
     /**
+     * @OA\Property(
+     *  description="One-time code for a solved captcha; required for login",
+     *  type="string",
+     *  example="some-token-123",
+     * )
+     */
+    public ?string $captcha_code = null;
+
+    /**
      * @Assert\NotBlank()
      * @OA\Property(
      *  property="email_address",

--- a/tests/Application/Middleware/CredentialsRecaptchaMiddlewareTest.php
+++ b/tests/Application/Middleware/CredentialsRecaptchaMiddlewareTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BigGive\Identity\Tests\Application\Middleware;
+
+use BigGive\Identity\Application\Middleware\CredentialsRecaptchaMiddleware;
+use BigGive\Identity\Domain\Credentials;
+use BigGive\Identity\Tests\TestCase;
+use Psr\Log\LoggerInterface;
+use ReCaptcha\ReCaptcha;
+use Slim\CallableResolver;
+use Slim\Psr7\Factory\ResponseFactory;
+use Slim\Psr7\Response;
+use Slim\Routing\Route;
+use Slim\Exception\HttpUnauthorizedException;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class CredentialsRecaptchaMiddlewareTest extends TestCase
+{
+    public function testFailure(): void
+    {
+        $serializer = $this->getAppInstance()->getContainer()->get(SerializerInterface::class);
+
+        $credentialsObject = $this->getTestCredentials();
+
+        $credentialsSerialised = $serializer->serialize($credentialsObject, 'json');
+        $credentials = json_decode($credentialsSerialised, true, 512, JSON_THROW_ON_ERROR);
+        $credentials['captcha_code'] = 'bad response';
+        $body = json_encode($credentials);
+
+        $request = $this->createRequest('POST', '/v1/auth');
+        $request->getBody()->write($body);
+
+        $this->expectException(HttpUnauthorizedException::class);
+        $this->expectExceptionMessage('Unauthorised');
+
+        // Because the 401 ends the request, we can dispatch this against realistic, full app
+        // middleware and test this piece of middleware in the process.
+        $this->getAppInstance()
+            ->getMiddlewareDispatcher()
+            ->handle($request);
+    }
+
+    public function testSuccess(): void
+    {
+        $serializer = $this->getAppInstance()->getContainer()->get(SerializerInterface::class);
+
+        $credentialsObject = $this->getTestCredentials();
+
+        $credentialsSerialised = $serializer->serialize($credentialsObject, 'json');
+        $credentials = json_decode($credentialsSerialised, true, 512, JSON_THROW_ON_ERROR);
+        $credentials['captcha_code'] = 'good response';
+        $body = json_encode($credentials);
+
+        $request = $this->createRequest('POST', '/v1/auth')
+            // Because we're only running the single middleware and not the app stack, we need
+            // to set this attribute manually to simulate what ClientIp middleware does on real
+            // runs.
+            ->withAttribute('client-ip', '1.2.3.4');
+        $request->getBody()->write($body);
+
+        $container = $this->getAppInstance()->getContainer();
+
+        // For the success case we can't fully handle the request without covering a lot of stuff
+        // outside the middleware, which is covered in `LoginTest`'s end to end action test already.
+        // So we are better creating an isolated middleware object to invoke.
+        $middleware = new CredentialsRecaptchaMiddleware(
+            $container->get(LoggerInterface::class), // null logger already set up
+            $container->get(ReCaptcha::class), // already mocked with success simulation
+            $container->get(SerializerInterface::class),
+        );
+        $response = $middleware->process($request, $this->getSuccessHandler());
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Simulate a route returning a 200 OK. Test methods should get here only when they expect auth
+     * success from the middleware.
+     */
+    private function getSuccessHandler(): Route
+    {
+        return new Route(
+            ['POST'],
+            '/v1/auth',
+            static function () {
+                return new Response(200);
+            },
+            new ResponseFactory(),
+            new CallableResolver()
+        );
+    }
+
+    private function getTestCredentials(): Credentials
+    {
+        $credentials = new Credentials();
+        $credentials->email_address = 'noel@example.com';
+        $credentials->raw_password = 'mySecurePassword123';
+
+        return $credentials;
+    }
+}

--- a/tests/Application/Middleware/PersonRecaptchaMiddlewareTest.php
+++ b/tests/Application/Middleware/PersonRecaptchaMiddlewareTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace BigGive\Identity\Tests\Application\Middleware;
 
-use BigGive\Identity\Application\Middleware\RecaptchaMiddleware;
+use BigGive\Identity\Application\Middleware\PersonRecaptchaMiddleware;
 use BigGive\Identity\Tests\TestCase;
 use BigGive\Identity\Tests\TestPeopleTrait;
 use Psr\Log\LoggerInterface;
@@ -16,7 +16,7 @@ use Slim\Routing\Route;
 use Slim\Exception\HttpUnauthorizedException;
 use Symfony\Component\Serializer\SerializerInterface;
 
-class RecaptchaMiddlewareTest extends TestCase
+class PersonRecaptchaMiddlewareTest extends TestCase
 {
     use TestPeopleTrait;
 
@@ -39,7 +39,7 @@ class RecaptchaMiddlewareTest extends TestCase
 
         // Because the 401 ends the request, we can dispatch this against realistic, full app
         // middleware and test this piece of middleware in the process.
-        $response = $this->getAppInstance()
+        $this->getAppInstance()
             ->getMiddlewareDispatcher()
             ->handle($request);
     }
@@ -68,7 +68,7 @@ class RecaptchaMiddlewareTest extends TestCase
         // outside the middleware, since that would mean creating a Person and so mocking DB bits
         // etc. So unlike for failure, we create an isolated middleware object to invoke.
 
-        $middleware = new RecaptchaMiddleware(
+        $middleware = new PersonRecaptchaMiddleware(
             $container->get(LoggerInterface::class), // null logger already set up
             $container->get(ReCaptcha::class), // already mocked with success simulation
             $container->get(SerializerInterface::class),

--- a/tests/Domain/CredentialsTest.php
+++ b/tests/Domain/CredentialsTest.php
@@ -12,10 +12,12 @@ class CredentialsTest extends TestCase
     public function testBuildAndJsonSerialize(): void
     {
         $credentials = new Credentials();
+        $credentials->captcha_code = 'model-only test code';
         $credentials->email_address = 'noel@example.com';
         $credentials->raw_password = 'mySecurePassword123';
 
         $expected = json_encode([
+            'captcha_code' => 'model-only test code',
             'email_address' => 'noel@example.com',
             'raw_password' => 'mySecurePassword123',
         ], JSON_THROW_ON_ERROR);


### PR DESCRIPTION
* Secure it with captcha and rate limit middleware
* Return `id` for convenience alongside the token