### PR TITLE
ID-11 – Update registration emails

### DIFF
--- a/app/repositories.php
+++ b/app/repositories.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use BigGive\Identity\Client\Mailer;
 use BigGive\Identity\Domain\Person;
 use BigGive\Identity\Repository\PersonRepository;
 use DI\ContainerBuilder;
@@ -11,7 +12,10 @@ use Psr\Container\ContainerInterface;
 return static function (ContainerBuilder $containerBuilder) {
     $containerBuilder->addDefinitions([
         PersonRepository::class => static function (ContainerInterface $c): PersonRepository {
-            return $c->get(EntityManagerInterface::class)->getRepository(Person::class);
+            $repo = $c->get(EntityManagerInterface::class)->getRepository(Person::class);
+            $repo->setMailerClient($c->get(Mailer::class));
+
+            return $repo;
         },
     ]);
 };

--- a/src/Application/Actions/Person/Create.php
+++ b/src/Application/Actions/Person/Create.php
@@ -6,7 +6,6 @@ namespace BigGive\Identity\Application\Actions\Person;
 
 use BigGive\Identity\Application\Actions\Action;
 use BigGive\Identity\Application\Auth\Token;
-use BigGive\Identity\Client\Mailer;
 use BigGive\Identity\Domain\Person;
 use BigGive\Identity\Repository\PersonRepository;
 use Laminas\Diactoros\Response\TextResponse;
@@ -60,7 +59,6 @@ class Create extends Action
 {
     public function __construct(
         LoggerInterface $logger,
-        private readonly Mailer $mailerClient,
         private readonly PersonRepository $personRepository,
         private readonly SerializerInterface $serializer,
         private readonly StripeClient $stripeClient,
@@ -136,17 +134,6 @@ class Create extends Action
 
         $token = Token::create((string) $person->getId(), false, $person->stripe_customer_id);
         $person->addCompletionJWT($token);
-
-        // After completely persisting Person, send them a registration success email
-        $requestBody = $person->toMailerPayload();
-        $sendSuccessful = $this->mailerClient->sendEmail($requestBody);
-
-        if (!$sendSuccessful) {
-            throw new HttpBadRequestException(
-                $this->request,
-                'Failed to send registration success email to newly registered donor.'
-            );
-        }
 
         return new TextResponse(
             $this->serializer->serialize(

--- a/src/Domain/Person.php
+++ b/src/Domain/Person.php
@@ -185,11 +185,6 @@ class Person
         return $this->last_name;
     }
 
-    public function getEmailAddress(): string
-    {
-        return $this->email_address;
-    }
-
     public function hashPassword(): void
     {
         if (!empty($this->raw_password)) {
@@ -211,11 +206,11 @@ class Person
     {
         $data = [
             'templateKey' => 'donor-registered',
-            'recipientEmailAddress' => $this->getEmailAddress(),
+            'recipientEmailAddress' => $this->email_address,
             'forGlobalCampaign' => false,
             'params' => [
                 'donorFirstName' => $this->getFirstName(),
-                'donorEmail' => $this->getEmailAddress(),
+                'donorEmail' => $this->email_address,
             ],
         ];
 

--- a/src/Domain/Person.php
+++ b/src/Domain/Person.php
@@ -175,12 +175,12 @@ class Person
         $this->id = $id;
     }
 
-    public function getFirstName(): string
+    public function getFirstName(): ?string
     {
         return $this->first_name;
     }
 
-    public function getLastName(): string
+    public function getLastName(): ?string
     {
         return $this->last_name;
     }

--- a/tests/Repository/PersonRepositoryTest.php
+++ b/tests/Repository/PersonRepositoryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BigGive\Identity\Tests\Repository;
+
+use BigGive\Identity\Client\Mailer;
+use BigGive\Identity\Domain\Person;
+use BigGive\Identity\Repository\PersonRepository;
+use BigGive\Identity\Tests\TestCase;
+use Prophecy\Argument;
+
+class PersonRepositoryTest extends TestCase
+{
+    public function testRegistrationMailSuccess(): void
+    {
+        $app = $this->getAppInstance();
+        $container = $app->getContainer();
+
+        $mailerProphecy = $this->prophesize(Mailer::class);
+        $mailerProphecy
+            ->sendEmail(Argument::type('array'))
+            ->shouldBeCalledOnce()
+            ->willReturn(true);
+
+        $container->set(Mailer::class, $mailerProphecy->reveal());
+
+        $repo = $container->get(PersonRepository::class);
+        $repo->setMailerClient($mailerProphecy->reveal());
+
+        $this->assertTrue($repo->sendRegisteredEmail(new Person()));
+    }
+
+    public function testRegistrationMailFailure(): void
+    {
+        $app = $this->getAppInstance();
+        $container = $app->getContainer();
+
+        $mailerProphecy = $this->prophesize(Mailer::class);
+        $mailerProphecy
+            ->sendEmail(Argument::type('array'))
+            ->shouldBeCalledOnce()
+            ->willReturn(false);
+
+        $container->set(Mailer::class, $mailerProphecy->reveal());
+
+        $repo = $container->get(PersonRepository::class);
+        $repo->setMailerClient($mailerProphecy->reveal());
+
+        $this->assertFalse($repo->sendRegisteredEmail(new Person()));
+    }
+}


### PR DESCRIPTION
* Move the object-related mailing support to the `PersonRepository`
* Call the new helper when an `Update` leads to a password being set for the
first time
* Tighten up `Person\Update` tests to more realistically reflect the newly-set
password scenario so we can effectively test the new logic there