### PR TITLE
ID-6 – fix type error with missing captcha

### DIFF
--- a/src/Application/Middleware/CredentialsRecaptchaMiddleware.php
+++ b/src/Application/Middleware/CredentialsRecaptchaMiddleware.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class CredentialsRecaptchaMiddleware extends RecaptchaMiddleware
 {
-    protected function getCode(ServerRequestInterface $request): string
+    protected function getCode(ServerRequestInterface $request): ?string
     {
         $body = (string) $request->getBody();
 

--- a/src/Application/Middleware/PersonRecaptchaMiddleware.php
+++ b/src/Application/Middleware/PersonRecaptchaMiddleware.php
@@ -10,7 +10,7 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 
 class PersonRecaptchaMiddleware extends RecaptchaMiddleware
 {
-    protected function getCode(ServerRequestInterface $request): string
+    protected function getCode(ServerRequestInterface $request): ?string
     {
         $body = (string) $request->getBody();
 
@@ -23,7 +23,7 @@ class PersonRecaptchaMiddleware extends RecaptchaMiddleware
                 Person::class,
                 'json'
             );
-            $captchaCode = $person->captcha_code ?? '';
+            $captchaCode = $person->captcha_code ?? null;
         } catch (UnexpectedValueException $exception) { // This is the Serializer one, not the global one
             // No-op. Allow verification with blank string to occur. This will fail with the live
             // service, but can be mocked with success in unit tests so we can test handling of other

--- a/src/Application/Middleware/RecaptchaMiddleware.php
+++ b/src/Application/Middleware/RecaptchaMiddleware.php
@@ -38,6 +38,11 @@ abstract class RecaptchaMiddleware implements MiddlewareInterface
         for ($counter = 0; $counter < $timesToAttemptCaptchaVerification; $counter++) {
             $captchaCode = $this->getCode($request);
 
+            if ($captchaCode === null) {
+                $this->logger->log(LogLevel::WARNING, 'Security: captcha code not sent');
+                $this->unauthorised($this->logger, true, $request);
+            }
+
             $result = $this->captcha->verify(
                 $captchaCode,
                 $request->getAttribute('client-ip') // Set to original IP by previous middleware
@@ -72,5 +77,5 @@ abstract class RecaptchaMiddleware implements MiddlewareInterface
         return $handler->handle($request);
     }
 
-    abstract protected function getCode(ServerRequestInterface $request): string;
+    abstract protected function getCode(ServerRequestInterface $request): ?string;
 }

--- a/tests/Application/Actions/Person/CreateTest.php
+++ b/tests/Application/Actions/Person/CreateTest.php
@@ -103,6 +103,9 @@ class CreateTest extends TestCase
 
     public function testMissingCaptcha(): void
     {
+        $this->expectException(HttpUnauthorizedException::class);
+        $this->expectExceptionMessage('Unauthorised');
+
         $person = $this->getTestPerson();
 
         $app = $this->getAppInstance();
@@ -120,20 +123,7 @@ class CreateTest extends TestCase
             'email_address' => $person->email_address,
         ]);
 
-        $response = $app->handle($request);
-        $payloadJSON = (string) $response->getBody();
-
-        $this->assertEquals(400, $response->getStatusCode());
-        $this->assertJson($payloadJSON);
-
-        $expectedJSON = json_encode([
-            'error' => [
-                'description' => 'Validation error: Captcha is required to create an account',
-                'type' => 'BAD_REQUEST',
-            ],
-            'statusCode' => 400,
-        ], JSON_THROW_ON_ERROR);
-        $this->assertJsonStringEqualsJsonString($expectedJSON, $payloadJSON);
+        $app->handle($request);
     }
 
     public function testBadJSON(): void


### PR DESCRIPTION
Resolves crash seen in `Actions\Login` with bad client-data. Should also protect against similar anywhere either reCAPTCHA middleware's used.

Also expands unit tests to cover both bad and absent captcha codes.