### PR TITLE
ID-29 – fix pre-persist check

### DIFF
--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -31,9 +31,7 @@ class HttpErrorHandler extends SlimErrorHandler
             'An internal error has occurred while processing your request.'
         );
 
-        $this->logger->error('HttpErrorHandler exception.' .
-            'Message: ' . $this->exception->getMessage() .
-            '\nTrace: ' . $this->exception->getTraceAsString());
+        $this->logger->info('HttpErrorHandler exception: ' . $this->exception->getMessage());
 
         if ($exception instanceof HttpException) {
             $statusCode = $exception->getCode();

--- a/src/Repository/PersonRepository.php
+++ b/src/Repository/PersonRepository.php
@@ -44,15 +44,16 @@ class PersonRepository extends EntityRepository
      */
     public function persist(Person $person): Person
     {
-        $existingPerson = null;
-        if (!empty($person->email_address)) {
-            $existingPerson = $this->findPasswordEnabledPersonByEmailAddress($person->email_address);
-        }
+        $passwordIsToBeSet = !empty($person->raw_password) && !empty($person->email_address);
 
-        if ($existingPerson) {
-            throw new \LogicException(sprintf(
-                'Person already exists with password and email address %s' . $person->email_address
-            ));
+        if ($passwordIsToBeSet) {
+            $existingPerson = $this->findPasswordEnabledPersonByEmailAddress($person->email_address);
+            if ($existingPerson !== null) {
+                throw new \LogicException(sprintf(
+                    'Person already exists with password and email address %s',
+                    $person->email_address
+                ));
+            }
         }
 
         $person->hashPassword();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -65,7 +65,7 @@ class TestCase extends PHPUnit_TestCase
         $redisProphecy = $this->prophesize(Redis::class);
         $redisProphecy->isConnected()->willReturn(true);
         $redisProphecy->mget(['identity-test:10d49f663215e991d10df22692f03e89'])->willReturn(null);
-        $redisProphecy->mget(['identity-test:BigGive__Identity__Domain__Person__CLASSMETADATA__'])->wilLReturn(null);
+        $redisProphecy->mget(['identity-test:BigGive__Identity__Domain__Person__CLASSMETADATA__'])->willReturn(null);
         // symfony/cache Redis adapter apparently does something around prepping value-setting
         // through a fancy pipeline() and calls this.
         $redisProphecy->multi(Argument::any())->willReturn();


### PR DESCRIPTION
When an existing Person has a password but the new Person to patch doesn't.

Also fix a runtime crash typo when the `LogicException` is correctly thrown.