### PR TITLE
Allow GETing password reset token so donate frontend can show an error if it doesn't exist / is expired

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use BigGive\Identity\Application\Actions\ChangePasswordUsingToken;
 use BigGive\Identity\Application\Actions\CreatePasswordResetToken;
 use BigGive\Identity\Application\Actions\GetCreditFundingInstructions;
+use BigGive\Identity\Application\Actions\GetPasswordResetToken;
 use BigGive\Identity\Application\Actions\Login;
 use BigGive\Identity\Application\Actions\Person;
 use BigGive\Identity\Application\Actions\Status;
@@ -49,6 +50,8 @@ return function (App $app) {
         )
             ->add(PlainRecaptchaMiddleware::class)
         ;
+
+        $versionGroup->get('/password-reset-token/{base58:[A-Za-z0-9-]{22}}', GetPasswordResetToken::class);
 
         $versionGroup->post('/change-forgotten-password', ChangePasswordUsingToken::class)
         ;

--- a/src/Application/Actions/CreatePasswordResetToken.php
+++ b/src/Application/Actions/CreatePasswordResetToken.php
@@ -52,7 +52,8 @@ class CreatePasswordResetToken extends Action
             return new JsonResponse([]);
         }
 
-        $token = new PasswordResetToken($person);
+
+        $token = PasswordResetToken::random($person);
 
         $resetLink = $accountManagementBaseUrl . '/reset-password' . "?token=" . urlencode($token->toBase58Secret());
 

--- a/src/Application/Actions/GetPasswordResetToken.php
+++ b/src/Application/Actions/GetPasswordResetToken.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BigGive\Identity\Application\Actions;
+
+use BigGive\Identity\Repository\PasswordResetTokenRepository;
+use BigGive\Identity\Repository\PersonRepository;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Log\LoggerInterface;
+use Slim\Exception\HttpNotFoundException;
+use Symfony\Component\Uid\Uuid;
+
+class GetPasswordResetToken extends Action
+{
+    public function __construct(
+        LoggerInterface $logger,
+        private readonly PasswordResetTokenRepository $tokenRepository,
+    ) {
+        parent::__construct($logger);
+    }
+
+    protected function action(Request $request, array $args): Response
+    {
+        $uuid = Uuid::fromBase58((string) ($args['base58'] ?? throw new HttpNotFoundException($request)));
+        $token = $this->tokenRepository->findForUse($uuid);
+
+        if ($token === null) {
+            throw new HttpNotFoundException($request);
+        }
+
+        return new JsonResponse(
+        // we don't really need any response body, the client can just go on the status. But it would feel weird to send
+        // an empty response.
+            ['valid' => true]
+        );
+    }
+}

--- a/src/Domain/PasswordResetToken.php
+++ b/src/Domain/PasswordResetToken.php
@@ -43,12 +43,22 @@ class PasswordResetToken
      */
     private ?\DateTimeImmutable $used = null;
 
-    public function __construct(Person $person)
+    private function __construct(Person $person, Uuid $uuid)
     {
         $this->person = $person;
-        $this->secret = Uuid::v4();
+        $this->secret = $uuid;
         $this->created_at = new \DateTime();
         $this->updated_at = new \DateTime();
+    }
+
+    public static function fromBase58(Person $person, string $base58Token): self
+    {
+        return new self($person, Uuid::fromBase58($base58Token));
+    }
+
+    public static function random(Person $person): self
+    {
+        return new self($person, Uuid::v4());
     }
 
     public function toBase58Secret(): string

--- a/tests/Application/Actions/ChangePasswordWithTokenTest.php
+++ b/tests/Application/Actions/ChangePasswordWithTokenTest.php
@@ -26,7 +26,7 @@ class ChangePasswordWithTokenTest extends TestCase
         $person = new Person();
 
         $passwordResetTokenProphecy = $this->prophesize(PasswordResetTokenRepository::class);
-        $passwordResetToken = new PasswordResetToken($person);
+        $passwordResetToken = PasswordResetToken::random($person);
         $passwordResetToken->created_at = new \DateTime("59 minutes ago"); // almost expired
         $passwordResetTokenProphecy->findForUse($secret)->willReturn($passwordResetToken);
         $passwordResetTokenProphecy->persist($passwordResetToken)->shouldBeCalled();
@@ -61,7 +61,7 @@ class ChangePasswordWithTokenTest extends TestCase
         $personId = Uuid::v4();
         $person = new Person();
 
-        $passwordResetToken = new PasswordResetToken($person);
+        $passwordResetToken = PasswordResetToken::random($person);
         $passwordResetToken->created_at = new \DateTime("62 minutes ago");
 
         $passwordResetTokenProphecy = $this->prophesize(PasswordResetTokenRepository::class);
@@ -94,7 +94,7 @@ class ChangePasswordWithTokenTest extends TestCase
         $person = new Person();
 
         $passwordResetTokenProphecy = $this->prophesize(PasswordResetTokenRepository::class);
-        $passwordResetToken = new PasswordResetToken($person);
+        $passwordResetToken = PasswordResetToken::random($person);
         $passwordResetToken->created_at = new \DateTime("59 minutes ago"); // almost expired
         $passwordResetTokenProphecy->findForUse($secret)->willReturn($passwordResetToken);
         $passwordResetTokenProphecy->persist($passwordResetToken)->shouldBeCalled();
@@ -134,7 +134,7 @@ class ChangePasswordWithTokenTest extends TestCase
         $person = new Person();
 
         $passwordResetTokenProphecy = $this->prophesize(PasswordResetTokenRepository::class);
-        $passwordResetToken = new PasswordResetToken($person);
+        $passwordResetToken = PasswordResetToken::random($person);
         $passwordResetToken->created_at = new \DateTime("59 minutes ago"); // almost expired
         $passwordResetTokenProphecy->findForUse($secret)->willReturn($passwordResetToken);
 

--- a/tests/Application/Actions/GetPasswordTokenTest.php
+++ b/tests/Application/Actions/GetPasswordTokenTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace BigGive\Identity\Tests\Application\Actions;
+
+use BigGive\Identity\Domain\PasswordResetToken;
+use BigGive\Identity\Domain\Person;
+use BigGive\Identity\Repository\PasswordResetTokenRepository;
+use BigGive\Identity\Repository\PersonRepository;
+use BigGive\Identity\Tests\TestCase;
+use DI\Container;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Exception\HttpBadRequestException;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\UuidV4;
+
+class GetPasswordTokenTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testCanChangePassword(): void
+    {
+        // arrange
+        $base58Token = 'XT6A2y3ZedFerQnRnLFLsS';
+        $secret = Uuid::fromBase58($base58Token);
+        $passwordResetToken = PasswordResetToken::fromBase58(new Person(), $base58Token);
+
+        $passwordResetTokenRepoProphecy = $this->prophesize(PasswordResetTokenRepository::class);
+        $passwordResetTokenRepoProphecy->findForUse($secret)->willReturn($passwordResetToken);
+
+        $app = $this->getAppInstance();
+        $container = $app->getContainer();
+        assert($container instanceof Container);
+        $container->set(PasswordResetTokenRepository::class, $passwordResetTokenRepoProphecy->reveal());
+
+        // act
+        $response = $app->handle($this->createRequest('GET', "/v1/password-reset-token/$base58Token"));
+
+        // assert
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString('{"valid": true}', $response->getBody()->getContents());
+    }
+}

--- a/tests/semi-manual-testing/create-password-reset-token.http
+++ b/tests/semi-manual-testing/create-password-reset-token.http
@@ -1,5 +1,6 @@
 POST http://localhost:30050/v1/password-reset-token
 Content-Type: application/json
+x-captcha-code: captcha-code
 
 {
   "email_address":  "donor@weliketodonatebutweforgotpasswords.com"


### PR DESCRIPTION
I'll start the PR to DON before asking for review so both can be reviewed together.