### PR TITLE
Supress log output and deprecations in PhpUnit tests

### DIFF
--- a/tests/Application/Actions/StatusTest.php
+++ b/tests/Application/Actions/StatusTest.php
@@ -91,7 +91,7 @@ class StatusTest extends TestCase
     }
 
     private function getConnectedMockEntityManager(
-        string $proxyPath = '/var/www/html/var/doctrine/proxies',
+        string $proxyPath = __DIR__ . '/../../../var/doctrine/proxies',
     ): EntityManagerInterface {
         $config = ORM\ORMSetup::createAnnotationMetadataConfiguration(
             ['/var/www/html/src/Domain'],
@@ -105,7 +105,7 @@ class StatusTest extends TestCase
         // No auto-generation – like live mode – for these tests.
         $config->setAutoGenerateProxyClasses(false);
         $config->setMetadataDriverImpl(
-            new AnnotationDriver(new AnnotationReader(), ['/var/www/html/src/Domain']),
+            new AnnotationDriver(new AnnotationReader(), [__DIR__ . '/../../Domain']),
         );
 
         $connectionProphecy = $this->prophesize(Connection::class);

--- a/tests/Application/Actions/StatusTest.php
+++ b/tests/Application/Actions/StatusTest.php
@@ -91,8 +91,9 @@ class StatusTest extends TestCase
     }
 
     private function getConnectedMockEntityManager(
-        string $proxyPath = __DIR__ . '/../../../var/doctrine/proxies',
+        ?string $proxyPath = null,
     ): EntityManagerInterface {
+        $proxyPath ??= realpath(__DIR__ . '/../../../var/doctrine/proxies');
         $config = ORM\ORMSetup::createAnnotationMetadataConfiguration(
             ['/var/www/html/src/Domain'],
             false, // Simulate live mode for these tests.

--- a/tests/Application/Actions/StatusTest.php
+++ b/tests/Application/Actions/StatusTest.php
@@ -91,9 +91,8 @@ class StatusTest extends TestCase
     }
 
     private function getConnectedMockEntityManager(
-        ?string $proxyPath = null,
+        string $proxyPath = '/var/www/html/var/doctrine/proxies',
     ): EntityManagerInterface {
-        $proxyPath ??= realpath(__DIR__ . '/../../../var/doctrine/proxies');
         $config = ORM\ORMSetup::createAnnotationMetadataConfiguration(
             ['/var/www/html/src/Domain'],
             false, // Simulate live mode for these tests.
@@ -106,7 +105,7 @@ class StatusTest extends TestCase
         // No auto-generation – like live mode – for these tests.
         $config->setAutoGenerateProxyClasses(false);
         $config->setMetadataDriverImpl(
-            new AnnotationDriver(new AnnotationReader(), [__DIR__ . '/../../Domain']),
+            new AnnotationDriver(new AnnotationReader(), ['/var/www/html/src/Domain']),
         );
 
         $connectionProphecy = $this->prophesize(Connection::class);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use ReCaptcha\ReCaptcha;
 use Redis;
 use Slim\App;
@@ -47,6 +49,8 @@ class TestCase extends PHPUnit_TestCase
 
         // Build PHP-DI Container instance
         $container = $containerBuilder->build();
+
+        $container->set(LoggerInterface::class, new NullLogger());
 
         $recaptchaProphecy = $this->prophesize(ReCaptcha::class);
         $recaptchaProphecy->verify('good response', '1.2.3.4')

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,3 @@
 <?php
-
+error_reporting(E_ALL & ~E_DEPRECATED);
 require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Now successful test output fits easily on the screen for easy reading:

	barney@barney-l-xps:~/projects/identity$ vendor/bin/phpunit
	PHPUnit 9.5.25 #StandWithUkraine

	Warning:       No code coverage driver available

	................................................................. 65 / 73 ( 89%)
	........                                                          73 / 73 (100%)

	Time: 00:00.739, Memory: 30.00 MB

	OK (73 tests, 325 assertions)