### PR TITLE
Use docker image digest that build sucessfully yesterday

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     # generation-dependent tests to work.
     working_directory: /var/www/html
     docker:
-      - image: thebiggive/php@ab1ca53746a62196a5fb7386aa4dd1625b825d1da22ab19cbf155ae9e389ff60279
+      - image: thebiggive/php@sha256:ab1ca53746a62196a5fb7386aa4dd1625b825d1da22ab19cbf155ae9e389ff60
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     # generation-dependent tests to work.
     working_directory: /var/www/html
     docker:
-      - image: thebiggive/php@sha256:ab1ca53746a62196a5fb7386aa4dd1625b825d1da22ab19cbf155ae9e389ff60279B/279B4MBB
+      - image: thebiggive/php@ab1ca53746a62196a5fb7386aa4dd1625b825d1da22ab19cbf155ae9e389ff60279B/279B4MBB
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     # generation-dependent tests to work.
     working_directory: /var/www/html
     docker:
-      - image: thebiggive/php:dev-8.1
+      - image: thebiggive/php@sha256:ab1ca53746a62196a5fb7386aa4dd1625b825d1da22ab19cbf155ae9e389ff60279B/279B4MBB
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     # generation-dependent tests to work.
     working_directory: /var/www/html
     docker:
-      - image: thebiggive/php@ab1ca53746a62196a5fb7386aa4dd1625b825d1da22ab19cbf155ae9e389ff60279B
+      - image: thebiggive/php@ab1ca53746a62196a5fb7386aa4dd1625b825d1da22ab19cbf155ae9e389ff60279b
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     # generation-dependent tests to work.
     working_directory: /var/www/html
     docker:
-      - image: thebiggive/php@ab1ca53746a6219
+      - image: thebiggive/php@ab1ca53746a62196a5fb7386aa4dd1625b825d1da22ab19cbf155ae9e389ff60279B
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     # generation-dependent tests to work.
     working_directory: /var/www/html
     docker:
-      - image: thebiggive/php@ab1ca53746a62196a5fb7386aa4dd1625b825d1da22ab19cbf155ae9e389ff60279b
+      - image: thebiggive/php@ab1ca53746a62196a5fb7386aa4dd1625b825d1da22ab19cbf155ae9e389ff60279
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     # generation-dependent tests to work.
     working_directory: /var/www/html
     docker:
-      - image: thebiggive/php@ab1ca53746a62196a5fb7386aa4dd1625b825d1da22ab19cbf155ae9e389ff60279B/279B4MBB
+      - image: thebiggive/php@ab1ca53746a6219
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN


### PR DESCRIPTION
Using docker image digest from succesful build yesterday ( https://app.circleci.com/pipelines/github/thebiggive/identity/270/workflows/fbb6a973-2e07-438e-9757-4fe602361189/jobs/676).

But that shows the digest like:

```
Digest: sha256:ab1ca53746a62196a5fb7386aa4dd1625b825d1da22ab19cbf155ae9e389ff60279B/279B4MBB
Status: Downloaded newer image for thebiggive/php:dev-8.1
```

It seems I had to truncate the sha256 part to exactly 64 hex digits to make it work. Not sure what the other stuff at the end is.