### PR TITLE
ID-36: Allow registration if and when HiBP service is down

### DIFF
--- a/src/Domain/Person.php
+++ b/src/Domain/Person.php
@@ -290,7 +290,7 @@ class Person
         $notCompromisedValidator = new Assert\NotCompromisedPasswordValidator($httpClient);
         $notCompromisedValidator->initialize($context);
 
-        $notCompromisedValidator->validate($this->raw_password, new NotCompromisedPassword());
+        $notCompromisedValidator->validate($this->raw_password, new NotCompromisedPassword(skipOnError: true));
     }
 
     public function addCompletionJWT(string $completionJWT): void


### PR DESCRIPTION
See docs at https://symfony.com/doc/current/reference/constraints/NotCompromisedPassword.html#skiponerror