### PR TITLE
MAT-296: Store email address in stripe metadata for new accounts

### DIFF
--- a/src/Application/Actions/Person/Update.php
+++ b/src/Application/Actions/Person/Update.php
@@ -211,6 +211,7 @@ class Update extends Action
             // * to let the team see at a glance in the Stripe dashboard which donors (if created since April '23
             // have set a password.
             $customerDetails['metadata']['hasPasswordSince'] = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+            $customerDetails['metadata']['emailAddress'] = $person->email_address;
             $this->stripeClient->customers->update($person->stripe_customer_id, $customerDetails);
 
             // If the person didn't have a password before, but now does, send them a welcome email.


### PR DESCRIPTION
Following suggestion from Noel at https://github.com/thebiggive/matchbot/pull/520#discussion_r1170349755