### PR TITLE
Upload both coverage files to codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,8 @@ jobs:
 
       - codecov/upload:
           file: 'coverage.xml'
+      - codecov/upload:
+          file: 'coverage-integration.xml'
 
 workflows:
   build:


### PR DESCRIPTION
See:
* https://circleci.com/blog/making-code-coverage-easy-to-see-with-the-codecov-orb/
* https://docs.codecov.com/docs/merging-reports