### PR TITLE
MAT-306: Spike / wip retrieve list of transactions for cash balance

### DIFF
--- a/src/Application/Actions/Person/Get.php
+++ b/src/Application/Actions/Person/Get.php
@@ -79,6 +79,11 @@ class Get extends Action
                 'expand' => ['cash_balance'],
             ]);
 
+//            $transactions = $this->stripeClient->customers->allBalanceTransactions(parentId: $person->stripe_customer_id, params: ['limit' => 500]);
+
+            $transactions = $this->stripeClient->customers->allCashBalanceTransactions(parentId: $person->stripe_customer_id, params: ['limit' => 500]);
+
+
             // The hash must be non-null and reconciliation automatic for us to consider balances potentially
             // spendable. Note this does _not_ imply that any balances are non-zero right now, just that we
             // should check balances.
@@ -92,6 +97,7 @@ class Get extends Action
                 foreach ($stripeCustomer->cash_balance->available->toArray() as $currenyCode => $amount) {
                     if ($amount > 0) {
                         $person->cash_balance[$currenyCode] = $amount;
+                        $person->cach_balanance_transactions = $transactions->all()->toArray();
                     }
                 }
             }

--- a/src/Domain/Person.php
+++ b/src/Domain/Person.php
@@ -68,6 +68,8 @@ class Person
      */
     public array $cash_balance = [];
 
+    public array $cach_balanance_transactions = [];
+
     /**
      * @ORM\Id
      * @ORM\Column(type="uuid", unique=true)


### PR DESCRIPTION
Probably not for merging, just want to make sure I don't lose my finding of how to retrieve allCashBalanceTransactions . And note that allCashBalanceTransactions is a different method to allBalanceTransactions - the latter gives an empty collection in my test and is not what we want.