### PR TITLE
ID-41: Provide command to delete old and uselss Person records

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -7,6 +7,7 @@ use BigGive\Identity\Client;
 use BigGive\Identity\Domain\Normalizers\HasPasswordNormalizer;
 use DI\ContainerBuilder;
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM;
 use Doctrine\ORM\EntityManager;
@@ -56,6 +57,12 @@ return function (ContainerBuilder $containerBuilder) {
                 "identity-{$c->get(SettingsInterface::class)->get('appEnv')}",
                 3600, // Allow Auto-clearing cache/rate limit data after an hour.
             );
+        },
+        Connection::class => static function (ContainerInterface $c): Connection {
+            $em = $c->get(EntityManagerInterface::class);
+            \assert($em instanceof EntityManagerInterface);
+
+            return $em->getConnection();
         },
 
         EntityManagerInterface::class => static function (ContainerInterface $c): EntityManagerInterface {

--- a/identity
+++ b/identity
@@ -3,6 +3,7 @@
 
 declare(strict_types=1);
 
+use BigGive\Identity\Application\Commands\DeleteUnusablePersonRecords;
 use BigGive\Identity\Application\Commands\PopulateUsers;
 use BigGive\Identity\Repository\PersonRepository;
 use Psr\Log\LoggerInterface;
@@ -16,10 +17,16 @@ $cliApp = new Application();
 $personRepository = $psr11App->get(PersonRepository::class);
 \assert($personRepository instanceof PersonRepository);
 
+$connection = $psr11App->get(\Doctrine\DBAL\Connection::class);
+\assert($connection instanceof \Doctrine\DBAL\Connection);
+
+$now = new \DateTimeImmutable();
+
 $commands = [
     new PopulateUsers(
         $personRepository,
     ),
+    new DeleteUnusablePersonRecords($connection, $now),
 ];
 
 foreach ($commands as $command) {

--- a/integrationTests/DeleteUnusablePersonRecordsTest.php
+++ b/integrationTests/DeleteUnusablePersonRecordsTest.php
@@ -74,8 +74,9 @@ class DeleteUnusablePersonRecordsTest extends IntegrationTest
         $this->connection->executeStatement(<<<SQL
             INSERT INTO Person 
                 (id, first_name, last_name, email_address, created_at, updated_at, password) VALUES
-                ('{$this->personId->toBinary()}', 'first', 'last', '$this->randomEmail', '$createdAt', '$createdAt', $password)
-            SQL
+                (:id, 'first', 'last', '$this->randomEmail', '$createdAt', '$createdAt', $password)
+            SQL,
+            ['id' => $this->personId->toBinary()]
         );
     }
 

--- a/integrationTests/DeleteUnusablePersonRecordsTest.php
+++ b/integrationTests/DeleteUnusablePersonRecordsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace BigGive\Identity\IntegrationTests;
+
+use BigGive\Identity\Application\Commands\DeleteUnusablePersonRecords;
+use BigGive\Identity\Domain\Person;
+use BigGive\Identity\Repository\PersonRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Uid\UuidV4;
+
+class DeleteUnusablePersonRecordsTest extends IntegrationTest
+{
+    private PersonRepository $personRepository;
+    private Connection $connection;
+    private \DateTimeImmutable $now;
+    private UuidV4 $personId;
+    private string $randomEmail;
+    private CommandTester $commandTester;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->now = new \DateTimeImmutable('2020-11-30 12:00:00');
+
+        $this->personRepository = $this->getService(PersonRepository::class);
+        $this->connection = $this->getService(Connection::class);
+        $this->personId = \Symfony\Component\Uid\Uuid::v4();
+        $this->randomEmail = 'test_delete_unusable' . random_int(1, 1_000_000) . '@thebiggivetest.co.uk';
+        $this->commandTester = new CommandTester(new DeleteUnusablePersonRecords($this->connection, $this->now));
+    }
+
+    public function testItDeletesA32HourOldPasswordlessPerson(): void
+    {
+        $this->addPersonToDatabase(createdAt: '2020-11-29 04:00:00', withPassword: false);
+
+        $this->commandTester->execute([]);
+
+        $this->assertNull($this->personRepository->find($this->personId));
+    }
+
+    public function testItDoesNotDeletesALessThan32HourOldPasswordlessPerson(): void
+    {
+        $this->addPersonToDatabase(createdAt: '2020-11-29 04:00:01', withPassword: false);
+
+        $this->commandTester->execute([]);
+
+        $this->assertNotNull($this->personRepository->find($this->personId));
+    }
+
+    public function testItDoesNotDeleteA32HourOldPasswordHavingPerson(): void
+    {
+        $this->addPersonToDatabase(createdAt: '2020-11-29 04:00:00', withPassword: true);
+
+        $this->commandTester->execute([]);
+
+        $this->assertNotNull($this->personRepository->find($this->personId));
+    }
+
+    public function testItDoesNotDeletesALessThan32HourOldPasswordHavingPerson(): void
+    {
+        $this->addPersonToDatabase(createdAt: '2020-11-29 04:00:01', withPassword: true);
+
+        $this->commandTester->execute([]);
+
+        $this->assertNotNull($this->personRepository->find($this->personId));
+    }
+
+    public function addPersonToDatabase(string $createdAt, bool $withPassword): void
+    {
+        $password = $withPassword ? '\'$2y$10$4..1A/6AYEi7aL1sKz1M3OPKKSZYBGXXCoH7mL88ZwzA4KO.c9asK\'' : 'null';
+
+        $this->connection->executeStatement(<<<SQL
+            INSERT INTO Person 
+                (id, first_name, last_name, email_address, created_at, updated_at, password) VALUES
+                ('{$this->personId->toBinary()}', 'first', 'last', '$this->randomEmail', '$createdAt', '$createdAt', $password)
+            SQL
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->connection->executeStatement('DELETE FROM Person where Person.email_address like \'test_delete_unusable%\';');
+    }
+}

--- a/src/Application/Commands/DeleteUnusablePersonRecords.php
+++ b/src/Application/Commands/DeleteUnusablePersonRecords.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace BigGive\Identity\Application\Commands;
+
+use BigGive\Identity\Application\Auth\Token;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * If a person does not have a saved password, and has been in the database long enough that we know their
+ * JWT can't still be valid, then the record is useless so we delete it. They would need a new record next
+ * time they come to the website anyway.
+ */
+#[AsCommand(name: 'identity:populate-test-users')]
+class DeleteUnusablePersonRecords extends Command
+{
+    public function __construct(private Connection $connection, private \DateTimeImmutable $now)
+    {
+        parent::__construct();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /**
+         * Passwordless person records really become useless IMHO imediatly when the 8 hour validity expires. But
+         * for now lets only delete them when they are four times older that, i.e. after 32 hours, just in case
+         * we need to see them in the DB for support and diagnostic purposes.
+         */
+        $cutoffTimeIntervalSeconds = Token::VALIDITY_PERIOD_SECONDS * 4;
+
+        $cuttOffTimeString = $this->now->sub(new \DateInterval('PT' . $cutoffTimeIntervalSeconds . 'S'))
+            ->format('c');
+
+        $this->connection->executeStatement(
+            <<<'SQL'
+                    DELETE FROM Person where password is null AND Person.updated_at <= :cutoff
+                    SQL,
+            ['cutoff' => $cuttOffTimeString]
+        );
+
+        return 0;
+    }
+}

--- a/src/Application/Commands/DeleteUnusablePersonRecords.php
+++ b/src/Application/Commands/DeleteUnusablePersonRecords.php
@@ -34,12 +34,14 @@ class DeleteUnusablePersonRecords extends Command
         $cuttOffTimeString = $this->now->sub(new \DateInterval('PT' . $cutoffTimeIntervalSeconds . 'S'))
             ->format('c');
 
-        $this->connection->executeStatement(
+        $deletedCount = $this->connection->executeStatement(
             <<<'SQL'
                     DELETE FROM Person where password is null AND Person.updated_at <= :cutoff
                     SQL,
             ['cutoff' => $cuttOffTimeString]
         );
+
+        $output->writeln("Deleted $deletedCount useless Person records from before $cuttOffTimeString.");
 
         return 0;
     }

--- a/src/Application/Commands/DeleteUnusablePersonRecords.php
+++ b/src/Application/Commands/DeleteUnusablePersonRecords.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * JWT can't still be valid, then the record is useless so we delete it. They would need a new record next
  * time they come to the website anyway.
  */
-#[AsCommand(name: 'identity:populate-test-users')]
+#[AsCommand(name: 'identity:delete-unusable-person-records')]
 class DeleteUnusablePersonRecords extends Command
 {
     public function __construct(private Connection $connection, private \DateTimeImmutable $now)


### PR DESCRIPTION
The plan is to set up a cron job to run this command in production and staging.

To test in dev environment, you can run it manually like so:

```
~/projects/identity$ docker-compose exec app ./identity identity:delete-unusable-person-records
Deleted 0 useless Person records from before 2023-11-07T08:38:21+00:00.
```