### PR TITLE
ID-44: Use new stricter Symfony email address validation in creating …

### DIFF
--- a/src/Application/Actions/CreatePasswordResetToken.php
+++ b/src/Application/Actions/CreatePasswordResetToken.php
@@ -65,7 +65,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
         /** @var array $decoded */
         $decoded = json_decode($request->getBody()->__toString(), true, 512, \JSON_THROW_ON_ERROR);
         $email = (string) $decoded['email_address'];
-        $violations = $this->validator->validate($email, constraints: new Email());
+        $violations = $this->validator->validate($email, constraints: new Email(mode: Email::VALIDATION_MODE_HTML5));
         if (count($violations) > 0) {
             throw new HttpBadRequestException($request, 'Invalid email address');
         }


### PR DESCRIPTION
…password reset token

We've updated to a new version of Symfony's validator and it wants us to choose this new validation mode as a future version is going to take the old mode away.

For details of change see ticket at Symfony:
https://github.com/symfony/symfony/issues/41855

And details of the html5 validtion mode when it was introduced: https://symfony.com/blog/new-in-symfony-4-1-html5-email-validation