### PR TITLE
DON-1072: Remove support for recaptcha

### DIFF
--- a/src/Application/Middleware/CredentialsRecaptchaMiddleware.php
+++ b/src/Application/Middleware/CredentialsRecaptchaMiddleware.php
@@ -21,9 +21,4 @@ class CredentialsRecaptchaMiddleware extends RecaptchaMiddleware
 
         return $credentials->captcha_code;
     }
-
-    protected function isUsingFriendlyCaptcha(ServerRequestInterface $request): true
-    {
-        return true;
-    }
 }

--- a/src/Application/Middleware/PersonRecaptchaMiddleware.php
+++ b/src/Application/Middleware/PersonRecaptchaMiddleware.php
@@ -32,9 +32,4 @@ class PersonRecaptchaMiddleware extends RecaptchaMiddleware
 
         return $captchaCode;
     }
-
-    protected function isUsingFriendlyCaptcha(ServerRequestInterface $request): true
-    {
-        return true;
-    }
 }

--- a/src/Application/Middleware/PlainRecaptchaMiddleware.php
+++ b/src/Application/Middleware/PlainRecaptchaMiddleware.php
@@ -15,9 +15,4 @@ class PlainRecaptchaMiddleware extends RecaptchaMiddleware
 
         return reset($captchaHeaders);
     }
-
-    protected function isUsingFriendlyCaptcha(ServerRequestInterface $request): true
-    {
-        return true;
-    }
 }


### PR DESCRIPTION
Yesterday we deployed a frontend version that doesn't use recaptcha and only uses friendly captcha. So there's no need for identity to deal with recaptcha any more.