### PR TITLE
ID-47: Set password using emailed token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,6 @@ jobs:
 
       - run: composer run sa:check
 
-      - run: cd docs && apt update && apt install -y npm && npm i swagger-ui-dist
-
-      - run: composer run docs # Ensure OpenAPI annotations remain valid
-
       - run: composer run doctrine:generate-proxies
 
       - run: composer run test
@@ -67,6 +63,10 @@ jobs:
       - run: composer run doctrine:validate -v
 
       - run: composer run integration-test
+
+      - run: composer run docs # Ensure OpenAPI annotations remain valid
+
+      - run: cd docs && apt update && apt install -y npm && npm i swagger-ui-dist
 
       - store_artifacts:
           path: docs

--- a/app/routes.php
+++ b/app/routes.php
@@ -37,6 +37,13 @@ return function (App $app) {
         $versionGroup->put('/people/{personId:[a-z0-9-]{36}}', Person\Update::class)
             ->add(PersonPatchAuthMiddleware::class);
 
+        // no special auth needed for this, as the route is all about authentication auth is handled by the
+        // controller itself.
+        $versionGroup->post(
+            '/people/setFirstPassword',
+            Person\SetFirstPassword::class
+        );
+
         $versionGroup->group('/people/{personId:[a-z0-9-]{36}}', function (Group $personGetGroup) {
             $personGetGroup->get('', Person\Get::class);
             $personGetGroup->get('/funding_instructions', GetDonationFundsTransferInstructions::class);

--- a/integrationTests/DeleteUnusablePersonRecordsTest.php
+++ b/integrationTests/DeleteUnusablePersonRecordsTest.php
@@ -80,7 +80,7 @@ class DeleteUnusablePersonRecordsTest extends IntegrationTest
                 ) VALUES
                 (
                     :id, 'first', 'last', '$this->randomEmail', '$createdAt', '$createdAt',
-                 $password, 0
+                 $password, null
                 )
             SQL,
             ['id' => $this->personId->toBinary()]

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -7,15 +7,12 @@ use BigGive\Identity\Domain\Person;
 use BigGive\Identity\Repository\PersonRepository;
 use DI\Container;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Slim\App;
 use Stripe\Service\CustomerService;
-use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints\NotCompromisedPasswordValidator;
 

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -17,6 +17,7 @@ use Stripe\Service\CustomerService;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints\NotCompromisedPasswordValidator;
 
 abstract class IntegrationTest extends TestCase
 {
@@ -114,11 +115,12 @@ abstract class IntegrationTest extends TestCase
      */
     protected function addPersonToToDB(string $emailAddress): Uuid
     {
-        $person = new Person();
+        $person = new Person(
+            notCompromisedPasswordValidator: $this->createStub(NotCompromisedPasswordValidator::class)
+        );
         $person->email_address = $emailAddress;
         $person->first_name = "Fred";
         $person->last_name = "Bloggs";
-        $person->raw_password = 'password';
         $person->stripe_customer_id = 'cus_1234567890';
 
         $this->getService(PersonRepository::class)->persist($person);

--- a/integrationTests/SetFirstPasswordWithTokenTest.php
+++ b/integrationTests/SetFirstPasswordWithTokenTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace BigGive\Identity\IntegrationTests;
+
+use BigGive\Identity\Application\Security\EmailVerificationService;
+use BigGive\Identity\Application\Security\Password;
+use BigGive\Identity\Domain\EmailVerificationToken;
+use BigGive\Identity\Domain\Person;
+use BigGive\Identity\Repository\PersonRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use GuzzleHttp\Psr7\ServerRequest;
+use Symfony\Component\Uid\Uuid;
+
+class SetFirstPasswordWithTokenTest extends IntegrationTest
+{
+    private string $emailAddress;
+    private string $personUUID;
+    private EmailVerificationToken $token;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->emailAddress = "someemail" . Uuid::v4() . "@example.com";
+
+        $this->personUUID = $this->addPersonToToDB($this->emailAddress)->toRfc4122();
+
+        $this->getService(EmailVerificationService::class)->storeTokenForEmail($this->emailAddress);
+
+        $this->token = $this->getService(EntityManagerInterface::class)->getRepository(EmailVerificationToken::class)
+            ->findOneBy(['email_address' => $this->emailAddress]) ?? throw new \Exception("token not found");
+    }
+
+    public function testCanSetPassword(): void
+    {
+        $response = $this->getApp()->handle(new ServerRequest(
+            method: 'POST',
+            uri: "/v1/people/setFirstPassword",
+            body: json_encode([
+                'personUuid' => $this->personUUID,
+                'secret' => $this->token->random_code,
+                'password' => 'p@55w0rd____',
+            ], JSON_THROW_ON_ERROR),
+        ));
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->getService(EntityManagerInterface::class)->clear();
+
+        $updatedPerson = $this->getService(PersonRepository::class)->find($this->personUUID);
+        \assert($updatedPerson instanceof Person);
+
+        Password::verify('p@55w0rd____', $updatedPerson);
+        $this->assertTrue($updatedPerson->email_address_verified, 'Person should have verified email address');
+    }
+
+    public function testCanNotSetPasswordWithWrongCode(): void
+    {
+        $this->markTestIncomplete();
+    }
+}

--- a/integrationTests/SetFirstPasswordWithTokenTest.php
+++ b/integrationTests/SetFirstPasswordWithTokenTest.php
@@ -51,7 +51,7 @@ class SetFirstPasswordWithTokenTest extends IntegrationTest
         \assert($updatedPerson instanceof Person);
 
         Password::verify('p@55w0rd____', $updatedPerson);
-        $this->assertTrue($updatedPerson->email_address_verified, 'Person should have verified email address');
+        $this->assertNotNull($updatedPerson->email_address_verified, 'Person should have verified email address');
     }
 
     public function testCanNotSetPasswordWithWrongCode(): void

--- a/integrationTests/SetFirstPasswordWithTokenTest.php
+++ b/integrationTests/SetFirstPasswordWithTokenTest.php
@@ -9,6 +9,7 @@ use BigGive\Identity\Domain\Person;
 use BigGive\Identity\Repository\PersonRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use GuzzleHttp\Psr7\ServerRequest;
+use Slim\Exception\HttpBadRequestException;
 use Symfony\Component\Uid\Uuid;
 
 class SetFirstPasswordWithTokenTest extends IntegrationTest
@@ -55,6 +56,15 @@ class SetFirstPasswordWithTokenTest extends IntegrationTest
 
     public function testCanNotSetPasswordWithWrongCode(): void
     {
-        $this->markTestIncomplete();
+        $this->expectException(HttpBadRequestException::class);
+        $this->getApp()->handle(new ServerRequest(
+            method: 'POST',
+            uri: "/v1/people/setFirstPassword",
+            body: json_encode([
+                'personUuid' => $this->personUUID,
+                'secret' => '123456',
+                'password' => 'p@55w0rd____',
+            ], JSON_THROW_ON_ERROR),
+        ));
     }
 }

--- a/src/Application/Actions/Action.php
+++ b/src/Application/Actions/Action.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BigGive\Identity\Application\Actions;
 
+use BigGive\Identity\Application\Actions\Person\Update;
 use BigGive\Identity\Domain\DomainException\DomainRecordNotFoundException;
 use OpenApi\Annotations as OA;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -14,6 +15,7 @@ use Slim\Exception\HttpNotFoundException;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotCompromisedPassword;
 use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
  * @OA\Info(title="Big Give Identity service", version="1.0.0"),
@@ -61,6 +63,26 @@ abstract class Action
      * @throws HttpBadRequestException
      */
     abstract protected function action(Request $request, array $args): Response;
+
+    public function violationsToHtml(ConstraintViolationListInterface $violations): string
+    {
+        $violationDetails = [];
+        foreach ($violations as $violation) {
+            $violationDetails[] = $this->summariseConstraintViolationAsHtmlSnippet($violation);
+        }
+
+        return implode('; ', $violationDetails);
+    }
+
+    public function violationsToPlainText(ConstraintViolationListInterface $violations): string
+    {
+        $violationDetails = [];
+        foreach ($violations as $violation) {
+            $violationDetails[] = $this->summariseConstraintViolation($violation);
+        }
+
+        return implode('; ', $violationDetails);
+    }
 
     /**
      * @return mixed

--- a/src/Application/Actions/Person/SetFirstPassword.php
+++ b/src/Application/Actions/Person/SetFirstPassword.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace BigGive\Identity\Application\Actions\Person;
+
+use BigGive\Identity\Application\Actions\Action;
+use BigGive\Identity\Application\Actions\ActionError;
+use BigGive\Identity\Domain\DomainException\DuplicateEmailAddressWithPasswordException;
+use BigGive\Identity\Domain\EmailVerificationToken;
+use BigGive\Identity\Repository\PersonRepository;
+use DI\NotFoundException;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Log\LoggerInterface;
+use Slim\Exception\HttpBadRequestException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Sets a password on a donor account for the first time. We only allow this if the user knows
+ * the secret email verification token code {@see EmailVerificationToken}, and the UUID of the account.
+ *
+ * They will get both encoded in a link when they make a donation.
+ */
+class SetFirstPassword extends Action
+{
+    public function __construct(
+        private readonly ValidatorInterface $validator,
+        private PersonRepository $personRepository,
+        LoggerInterface $logger
+    ) {
+        parent::__construct($logger);
+    }
+
+    protected function action(Request $request, array $args): Response
+    {
+        try {
+            $requestBody = json_decode(
+                (string)$request->getBody(),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            );
+            \assert(is_array($requestBody));
+        } catch (\JsonException $exception) {
+            return $this->validationError(
+                $exception->getMessage(),
+            );
+        }
+
+        $uuid = (string) $requestBody["personUuid"];
+        $_secret = (string) $requestBody["secret"];
+        $newPassword = (string) $requestBody["password"];
+
+        // @todo - reuse logic to check the secret from GetEmailVerificationToken class
+
+        $person = $this->personRepository->find($uuid);
+        if ($person == null) {
+            throw new NotFoundException();
+        }
+
+        $personHadPassword = $person->getPasswordHash() !== null;
+        if ($personHadPassword) {
+            throw new HttpBadRequestException($request, 'Password already exists');
+        }
+
+        $person->raw_password = $newPassword;
+
+        $violations = $this->validator->validate($person, null, ['complete']);
+        if (count($violations) > 0) {
+            $message = $this->violationsToPlainText($violations);
+            $htmlMessage = $this->violationsToHtml($violations);
+
+            return $this->validationError(
+                $message,
+                $message,
+                true,
+                htmlMessage: $htmlMessage,
+            );
+        }
+
+        // Assuming the secret above is correct we know that the person using this has access to the email address.
+        // Setting email_address_verified may unlock some functionality for them in the future, e.g.
+        // seeing donations made while not logged in, and perhaps regular giving.
+        $person->email_address_verified = true;
+
+        // code below duplicates from the Person\Update route but will be removed from there soon when
+        // we require all new passworded accounts to have verified email addresses. However may duplicate with
+        // another route we will create similar to this that creates a new account in a single step using a token
+        // that doesn't relate to an existing account.
+        try {
+            $this->personRepository->persist($person);
+        } catch (DuplicateEmailAddressWithPasswordException $duplicateException) {
+            $this->logger->warning(sprintf(
+                '%s failed to persist Person: %s',
+                __CLASS__,
+                $duplicateException->getMessage(),
+            ));
+
+            return $this->validationError(
+                logMessage: "Update not valid: {$duplicateException->getMessage()}",
+                publicMessage: 'Your password could not be set. There is already a password set for ' .
+                'your email address.',
+                errorType: ActionError::DUPLICATE_EMAIL_ADDRESS_WITH_PASSWORD,
+            );
+        }
+
+        return new JsonResponse([]);
+    }
+}

--- a/src/Application/Actions/Person/SetFirstPassword.php
+++ b/src/Application/Actions/Person/SetFirstPassword.php
@@ -100,7 +100,7 @@ class SetFirstPassword extends Action
         // Assuming the secret above is correct we know that the person using this has access to the email address.
         // Setting email_address_verified may unlock some functionality for them in the future, e.g.
         // seeing donations made while not logged in, and perhaps regular giving.
-        $person->email_address_verified = true;
+        $person->email_address_verified = $this->now;
 
         // code below duplicates from the Person\Update route but will be removed from there soon when
         // we require all new passworded accounts to have verified email addresses. However may duplicate with

--- a/src/Application/Actions/Person/SetFirstPassword.php
+++ b/src/Application/Actions/Person/SetFirstPassword.php
@@ -50,9 +50,9 @@ class SetFirstPassword extends Action
             );
         }
 
-        $uuid = (string) $requestBody["personUuid"];
-        $secret = (string) $requestBody["secret"];
-        $newPassword = (string) $requestBody["password"];
+        $uuid = (string) ($requestBody["personUuid"] ?? throw new HttpBadRequestException($request));
+        $secret = (string) ($requestBody["secret"] ?? throw new HttpBadRequestException($request));
+        $newPassword = (string) ($requestBody["password"] ?? throw new HttpBadRequestException($request));
 
         $person = $this->personRepository->find($uuid);
         if ($person === null || $person->email_address === null) {

--- a/src/Application/Actions/Person/Update.php
+++ b/src/Application/Actions/Person/Update.php
@@ -87,26 +87,6 @@ class Update extends Action
         parent::__construct($logger);
     }
 
-    public function violationsToPlainText(ConstraintViolationListInterface $violations): string
-    {
-        $violationDetails = [];
-        foreach ($violations as $violation) {
-            $violationDetails[] = $this->summariseConstraintViolation($violation);
-        }
-
-        return implode('; ', $violationDetails);
-    }
-
-    public function violationsToHtml(ConstraintViolationListInterface $violations): string
-    {
-        $violationDetails = [];
-        foreach ($violations as $violation) {
-            $violationDetails[] = $this->summariseConstraintViolationAsHtmlSnippet($violation);
-        }
-
-        return implode('; ', $violationDetails);
-    }
-
     /**
      * @param array $args
      * @return Response

--- a/src/Domain/Person.php
+++ b/src/Domain/Person.php
@@ -244,7 +244,7 @@ class Person
      * Historically we didn't require this, but will for new accounts in future and may create
      * an optional verification process that holders of old accounts can use.
      */
-    #[ORM\Column(nullable: true, type: 'datetime')]
+    #[ORM\Column(nullable: true, type: 'datetime_immutable')]
     public ?\DateTimeImmutable $email_address_verified = null;
 
     /** Always null in prod for now as can't be saved in DB, set to double in tests. */

--- a/src/Domain/Person.php
+++ b/src/Domain/Person.php
@@ -244,8 +244,8 @@ class Person
      * Historically we didn't require this, but will for new accounts in future and may create
      * an optional verification process that holders of old accounts can use.
      */
-    #[ORM\Column]
-    public bool $email_address_verified = false;
+    #[ORM\Column(nullable: true, type: 'datetime')]
+    public ?\DateTimeImmutable $email_address_verified = null;
 
     /** Always null in prod for now as can't be saved in DB, set to double in tests. */
     private ?Assert\NotCompromisedPasswordValidator $notCompromisedPasswordValidator = null;

--- a/src/Migrations/Version20250411105139.php
+++ b/src/Migrations/Version20250411105139.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BigGive\Identity\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250411105139 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Use timestamp instead of tinyint to record when email addresses were verified.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Person CHANGE email_address_verified email_address_verified TINYINT(1) NULL');
+        $this->addSql('UPDATE Person SET email_address_verified = null;');
+        $this->addSql('ALTER TABLE Person CHANGE email_address_verified email_address_verified DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('UPDATE Person SET email_address_verified = null;');
+        $this->addSql('ALTER TABLE Person CHANGE email_address_verified email_address_verified TINYINT(1) NOT NULL');
+    }
+}

--- a/src/Migrations/Version20250411110319.php
+++ b/src/Migrations/Version20250411110319.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BigGive\Identity\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250411110319 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fix drift between doctrine definitions and schema';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Person CHANGE email_address_verified email_address_verified DATETIME DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Person CHANGE email_address_verified email_address_verified DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+}

--- a/src/Migrations/Version20250411111120.php
+++ b/src/Migrations/Version20250411111120.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BigGive\Identity\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250411111120 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fix doctrine mappings drift again';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Person CHANGE email_address_verified email_address_verified DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Person CHANGE email_address_verified email_address_verified DATETIME DEFAULT NULL');
+    }
+}

--- a/src/Repository/EmailVerificationTokenRepository.php
+++ b/src/Repository/EmailVerificationTokenRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BigGive\Identity\Repository;
+
+use BigGive\Identity\Domain\EmailVerificationToken;
+use Doctrine\ORM\EntityManagerInterface;
+
+class EmailVerificationTokenRepository
+{
+    /** @psalm-suppress PossiblyUnusedMethod - used in DI */
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    public function findToken(
+        string $email_address,
+        string $tokenSecret,
+        \DateTimeImmutable $createdSince
+    ): ?EmailVerificationToken {
+        $emailVerificationToken = $this->em->createQuery(
+            dql: <<<'DQL'
+                SELECT t FROM BigGive\Identity\Domain\EmailVerificationToken t
+                WHERE t.email_address = :email
+                AND t.created_at > :created_since
+                AND t.random_code = :secret
+                ORDER BY t.created_at DESC
+                DQL
+        )->setParameters([
+            'secret' => $tokenSecret,
+            'email' => $email_address,
+            'created_since' => $createdSince,
+        ])->setMaxResults(1)->getOneOrNullResult();
+
+        \assert(is_null($emailVerificationToken) || $emailVerificationToken instanceof EmailVerificationToken);
+
+        return $emailVerificationToken;
+    }
+}


### PR DESCRIPTION
Allows a donor who has received an emailed link after donation to set a password for their new account.

On my local I'm getting errors like below when running integration tests but I can't work out quite why. I've tried clearing caches, and the integration tests are passing in circleci.

```

1) BigGive\Identity\IntegrationTests\SetFirstPasswordWithTokenTest::testCanSetPassword
Doctrine\DBAL\Exception\DriverException: An exception occurred while executing a query: SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '1' for column 'email_address_verified' at row 1

```

**EDIT: I fixed that error on my local by rebuilding the docker container and the identity database.**