### PR TITLE
ID-47: Show error page instead of password prompt if donor clicks lin…

### DIFF
--- a/src/Repository/EmailVerificationTokenRepository.php
+++ b/src/Repository/EmailVerificationTokenRepository.php
@@ -20,7 +20,13 @@ class EmailVerificationTokenRepository
         $emailVerificationToken = $this->em->createQuery(
             dql: <<<'DQL'
                 SELECT t FROM BigGive\Identity\Domain\EmailVerificationToken t
+                LEFT JOIN BigGive\Identity\Domain\Person p WITH (
+                    -- If there is already a password for this email address then this token is effectivley used should
+                    -- be considered expired.
+                    t.email_address = p.email_address and p.password IS NOT NULL
+                )
                 WHERE t.email_address = :email
+                AND p is null
                 AND t.created_at > :created_since
                 AND t.random_code = :secret
                 ORDER BY t.created_at DESC


### PR DESCRIPTION
…k to set password when they already have a password

Can happen just by clicking the link twice. It's not possible to set a password twice this way so we shouldn't show the form a second time.