### PR TITLE
Don't notify slack for failures on ephemeral branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,18 @@ workflows:
   build:
     jobs:
       - test:
+          filters:
+            branches:
+              # separate `build-and-notify` workflow for these branches includes sending notifications
+              ignore: ['main', 'develop']
+          context:
+            - docker-hub-creds
+  build-and-notify:
+    jobs:
+      - test:
+          filters:
+            branches:
+              only: ['main', 'develop']
           context:
             - docker-hub-creds
             - jira

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ workflows:
           filters:
             branches:
               # separate `build-and-notify` workflow for these branches includes sending notifications
-              ignore: ['main', 'develop']
+              ignore: ['main', 'develop', 'trunk']
           context:
             - docker-hub-creds
   build-and-notify:
@@ -91,7 +91,7 @@ workflows:
       - test:
           filters:
             branches:
-              only: ['main', 'develop']
+              only: ['main', 'develop', 'trunk']
           context:
             - docker-hub-creds
             - jira

--- a/src/Application/Actions/EmailVerificationToken/Create.php
+++ b/src/Application/Actions/EmailVerificationToken/Create.php
@@ -126,4 +126,5 @@ class Create extends Action
             ],
         ]);
     }
+
 }

--- a/src/Application/Actions/EmailVerificationToken/Create.php
+++ b/src/Application/Actions/EmailVerificationToken/Create.php
@@ -126,5 +126,4 @@ class Create extends Action
             ],
         ]);
     }
-
 }


### PR DESCRIPTION
As discuess in retro. The idea is to reduce the noise in the slack deployments channel to make it easier to pay attention promptly to anything that does appear there and fix any errors quickly that show up on permanent branches.