### PR TITLE
DON-1119: Limit token validity time for guest donors to 1 hour

### DIFF
--- a/integrationTests/DeleteUnusablePersonRecordsTest.php
+++ b/integrationTests/DeleteUnusablePersonRecordsTest.php
@@ -31,36 +31,36 @@ class DeleteUnusablePersonRecordsTest extends IntegrationTest
         $this->commandTester = new CommandTester(new DeleteUnusablePersonRecords($this->connection, $this->now));
     }
 
-    public function testItDeletesA32HourOldPasswordlessPerson(): void
+    public function testItDeletesA8HourOldPasswordlessPerson(): void
     {
-        $this->addPersonToDatabase(createdAt: '2020-11-29 04:00:00', withPassword: false);
+        $this->addPersonToDatabase(createdAt: '2020-11-30 04:00:00', withPassword: false);
 
         $this->commandTester->execute([]);
 
         $this->assertNull($this->personRepository->find($this->personId));
     }
 
-    public function testItDoesNotDeletesALessThan32HourOldPasswordlessPerson(): void
+    public function testItDoesNotDeletesALessThan8HourOldPasswordlessPerson(): void
     {
-        $this->addPersonToDatabase(createdAt: '2020-11-29 04:00:01', withPassword: false);
+        $this->addPersonToDatabase(createdAt: '2020-11-30 04:00:01', withPassword: false);
 
         $this->commandTester->execute([]);
 
         $this->assertNotNull($this->personRepository->find($this->personId));
     }
 
-    public function testItDoesNotDeleteA32HourOldPasswordHavingPerson(): void
+    public function testItDoesNotDeleteAn8HourOldPasswordHavingPerson(): void
     {
-        $this->addPersonToDatabase(createdAt: '2020-11-29 04:00:00', withPassword: true);
+        $this->addPersonToDatabase(createdAt: '2020-11-30 04:00:00', withPassword: true);
 
         $this->commandTester->execute([]);
 
         $this->assertNotNull($this->personRepository->find($this->personId));
     }
 
-    public function testItDoesNotDeletesALessThan32HourOldPasswordHavingPerson(): void
+    public function testItDoesNotDeletesALessThan8HourOldPasswordHavingPerson(): void
     {
-        $this->addPersonToDatabase(createdAt: '2020-11-29 04:00:01', withPassword: true);
+        $this->addPersonToDatabase(createdAt: '2020-11-30 04:00:01', withPassword: true);
 
         $this->commandTester->execute([]);
 

--- a/integrationTests/GetPersonTest.php
+++ b/integrationTests/GetPersonTest.php
@@ -20,7 +20,7 @@ class GetPersonTest extends IntegrationTest
         $response = $this->getApp()->handle(new ServerRequest(
             method: 'GET',
             uri: "/v1/people/{$uuid}",
-            headers: ['x-tbg-auth' => Token::create($uuid, true, '')],
+            headers: ['x-tbg-auth' => Token::create(new \DateTimeImmutable(), $uuid, true, '')],
         ));
 
         $decodedBody = json_decode($response->getBody()->getContents(), true);

--- a/src/Application/Actions/Login.php
+++ b/src/Application/Actions/Login.php
@@ -132,7 +132,7 @@ class Login extends Action
 
         return new JsonResponse([
             'id' => $id,
-            'jwt' => Token::create($id, true, $person->stripe_customer_id),
+            'jwt' => Token::create(new \DateTimeImmutable(), $id, true, $person->stripe_customer_id),
         ]);
     }
 

--- a/src/Application/Actions/Person/Create.php
+++ b/src/Application/Actions/Person/Create.php
@@ -242,7 +242,7 @@ class Create extends Action
         $person->setStripeCustomerId($customer->id);
         $this->personRepository->persist($person, false);
 
-        $token = Token::create((string)$person->getId(), false, $person->stripe_customer_id);
+        $token = Token::create(new \DateTimeImmutable(), (string)$person->getId(), false, $person->stripe_customer_id);
         $person->addCompletionJWT($token);
 
         if ($hasPassword) {

--- a/src/Application/Actions/Person/SetFirstPassword.php
+++ b/src/Application/Actions/Person/SetFirstPassword.php
@@ -4,6 +4,7 @@ namespace BigGive\Identity\Application\Actions\Person;
 
 use BigGive\Identity\Application\Actions\Action;
 use BigGive\Identity\Application\Actions\ActionError;
+use BigGive\Identity\Application\Auth\Token;
 use BigGive\Identity\Client\Mailer;
 use BigGive\Identity\Domain\DomainException\DuplicateEmailAddressWithPasswordException;
 use BigGive\Identity\Domain\EmailVerificationToken;
@@ -97,9 +98,7 @@ class SetFirstPassword extends Action
         // We allow slightly older tokens here than in GetEmailVerificationToken to account for time spent looking
         // at the token before using it.
         $oldestAllowedTokenCreationDate =
-            $this->now->modify('-8 hours')
-            ->modify('-5 minutes');
-
+            $this->now->sub(new \DateInterval('PT' . Token::COMPLETE_ACCOUNT_VALIDITY_PERIOD_SECONDS . 'S'));
         $token = $this->emailVerificationTokenRepository->findToken(
             email_address: $person->email_address,
             tokenSecret: $secret,

--- a/tests/Application/Actions/GetDonationFundsTransferInstructionsTest.php
+++ b/tests/Application/Actions/GetDonationFundsTransferInstructionsTest.php
@@ -60,7 +60,7 @@ class GetDonationFundsTransferInstructionsTest extends TestCase
             ->withQueryParams(['currency' => 'gbp'])
             ->withHeader(
                 'x-tbg-auth',
-                Token::create(static::$testPersonUuid, true, 'cus_aaaaaaaaaaaa11'),
+                Token::create(new \DateTimeImmutable(), static::$testPersonUuid, true, 'cus_aaaaaaaaaaaa11'),
             );
 
         $response = $app->handle($request);

--- a/tests/Application/Actions/Person/GetTest.php
+++ b/tests/Application/Actions/Person/GetTest.php
@@ -341,7 +341,10 @@ class GetTest extends TestCase
     private function buildRequest(string $personId, bool $withTipBalance = false): ServerRequestInterface
     {
         return $this->buildRequestRaw($personId)
-            ->withHeader('x-tbg-auth', Token::create(static::$testPersonUuid, true, 'cus_aaaaaaaaaaaa11'))
+            ->withHeader(
+                'x-tbg-auth',
+                Token::create(new \DateTimeImmutable(), static::$testPersonUuid, true, 'cus_aaaaaaaaaaaa11')
+            )
             ->withQueryParams([
                 'withTipBalances' => $withTipBalance ? 'true' : 'false',
             ]);

--- a/tests/Application/Actions/Person/UpdateTest.php
+++ b/tests/Application/Actions/Person/UpdateTest.php
@@ -187,7 +187,15 @@ class UpdateTest extends TestCase
         $this->getContainer()->set(PersonRepository::class, $personRepoProphecy->reveal());
 
         $request = $this->buildRequestRaw(static::$testPersonUuid, '<')
-            ->withHeader('x-tbg-auth', Token::create(static::$testPersonUuid, false, 'cus_aaaaaaaaaaaa11'));
+            ->withHeader(
+                'x-tbg-auth',
+                Token::create(
+                    new \DateTimeImmutable(),
+                    static::$testPersonUuid,
+                    false,
+                    'cus_aaaaaaaaaaaa11'
+                )
+            );
 
         $response = $app->handle($request);
         $payloadJSON = (string) $response->getBody();
@@ -207,7 +215,10 @@ class UpdateTest extends TestCase
     private function buildRequest(string $personId, array $payloadValues): ServerRequestInterface
     {
         return $this->buildRequestRaw($personId, json_encode($payloadValues, JSON_THROW_ON_ERROR))
-            ->withHeader('x-tbg-auth', Token::create(static::$testPersonUuid, false, 'cus_aaaaaaaaaaaa11'));
+            ->withHeader(
+                'x-tbg-auth',
+                Token::create(new \DateTimeImmutable(), static::$testPersonUuid, false, 'cus_aaaaaaaaaaaa11')
+            );
     }
 
     private function buildRequestRaw(string $personId, string $payloadLiteral): ServerRequestInterface


### PR DESCRIPTION
Also delete passwordless person records after 8 hours instead of 32, and reduce time to set password with link in donation email  by 5 minutes, to align with the new earliest deletion time.