### PR TITLE
Fix broken ephemeral account deletion

### DIFF
--- a/identity
+++ b/identity
@@ -6,7 +6,7 @@ declare(strict_types=1);
 use BigGive\Identity\Application\Commands\DeleteUnusablePersonRecords;
 use BigGive\Identity\Application\Commands\PopulateUsers;
 use BigGive\Identity\Repository\PersonRepository;
-use Stripe\StripeClient;
+use BigGive\Identity\Client;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 
@@ -21,8 +21,8 @@ $personRepository = $psr11App->get(PersonRepository::class);
 $connection = $psr11App->get(\Doctrine\DBAL\Connection::class);
 \assert($connection instanceof \Doctrine\DBAL\Connection);
 
-$stripeClient = $psr11App->get(StripeClient::class);
-\assert($stripeClient instanceof StripeClient);
+$stripeClient = $psr11App->get(Client\Stripe::class);
+\assert($stripeClient instanceof Client\Stripe);
 
 $logger = $psr11App->get(\Psr\Log\LoggerInterface::class);
 \assert($logger instanceof \Psr\Log\LoggerInterface);

--- a/integrationTests/DeleteUnusablePersonRecordsTest.php
+++ b/integrationTests/DeleteUnusablePersonRecordsTest.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
-use Stripe\StripeClient;
+use BigGive\Identity\Client;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Uid\UuidV4;
 
@@ -21,7 +21,7 @@ class DeleteUnusablePersonRecordsTest extends IntegrationTest
     private \DateTimeImmutable $now;
     private UuidV4 $personId;
     private string $randomEmail;
-    /** @var ObjectProphecy<StripeClient> */
+    /** @var ObjectProphecy<Client\Stripe> */
     private ObjectProphecy $stripeClientProphecy;
     private TestLogger $logger;
     private CommandTester $commandTester;
@@ -37,7 +37,7 @@ class DeleteUnusablePersonRecordsTest extends IntegrationTest
         $this->randomEmail = 'test_delete_unusable' . random_int(1, 1_000_000) . '@thebiggivetest.co.uk';
         $this->logger = new TestLogger();
 
-        $this->stripeClientProphecy = $this->prophesize(StripeClient::class);
+        $this->stripeClientProphecy = $this->prophesize(Client\Stripe::class);
 
         $this->commandTester = new CommandTester(new DeleteUnusablePersonRecords(
             $this->connection,

--- a/src/Application/Commands/DeleteUnusablePersonRecords.php
+++ b/src/Application/Commands/DeleteUnusablePersonRecords.php
@@ -5,9 +5,9 @@ namespace BigGive\Identity\Application\Commands;
 use Assert\Assertion;
 use BigGive\Identity\Application\Actions\Person\SetFirstPassword;
 use BigGive\Identity\Application\Auth\TokenService;
+use BigGive\Identity\Client;
 use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
-use Stripe\StripeClient;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,7 +24,7 @@ class DeleteUnusablePersonRecords extends Command
     public function __construct(
         private Connection $connection,
         private \DateTimeImmutable $now,
-        private StripeClient $stripeClient,
+        private Client\Stripe $stripeClient,
         private LoggerInterface $logger,
     ) {
         parent::__construct();

--- a/src/Client/Stripe.php
+++ b/src/Client/Stripe.php
@@ -7,12 +7,19 @@ namespace BigGive\Identity\Client;
 use BigGive\Identity\LoadTestServices\Stripe\StubCustomerService;
 use Stripe\Service\CustomerService;
 use Stripe\Service\PaymentIntentService;
+use Stripe\Service\PaymentMethodService;
 use Stripe\StripeClient;
 
 class Stripe
 {
     public CustomerService|StubCustomerService $customers;
     public ?PaymentIntentService $paymentIntents = null;
+
+    /**
+     * @psalm-suppress PropertyNotSetInConstructor - will crash if used in stub mode, but we can fix that when it
+     * happens.
+     */
+    public PaymentMethodService $paymentMethods;
 
     public function __construct(bool $stubbed, array $stripeOptions)
     {
@@ -31,6 +38,7 @@ class Stripe
         // and therefore no stubbed Stripe calls use these as yet.
         if (!$stubbed) {
             $this->paymentIntents = $stripeNativeClient->paymentIntents;
+            $this->paymentMethods = $stripeNativeClient->paymentMethods;
         }
 
         // Any other service will crash in either mode, as we don't implement a magic


### PR DESCRIPTION
The deletion of ephemeral (no password) accounts has been broken since https://github.com/thebiggive/identity/pull/231 was merged in May, since we tried to instantiate the off the shelf stripe client via the DI container without providing it with an API key.

Changing here to extend and use our existing \BigGive\Identity\Client\Stripe wrapper since we already have code to construct that in dependancies.php