### PR TITLE
Remove Doctrine `orm:ensure-production-settings` use in entrypoints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,6 @@
             "@doctrine:migrate",
             "./identity identity:populate-test-users"
         ],
-        "doctrine:ensure-prod": "./bin/doctrine orm:ensure-production-settings",
         "doctrine:migrate": "doctrine-migrations migrate --no-interaction --allow-no-migration",
         "doctrine:migrate:diff": ["@doctrine:cache:clear", "doctrine-migrations diff"],
         "doctrine:migrate:generate": "doctrine-migrations generate",

--- a/deploy/secrets_entrypoint_tasks.sh
+++ b/deploy/secrets_entrypoint_tasks.sh
@@ -18,9 +18,6 @@ if [ -n "$JWT_ID_SECRETS" ]; then
   export JWT_ID_SECRETS=$(echo "$JWT_ID_SECRETS" | base64 -d)
 fi
 
-# Make Doctrine check it's set up right, inc. using a real, persistent-across-runs cache e.g. Redis.
-composer doctrine:ensure-prod || exit 2
-
 echo "Running migrations before start if necessary..."
 composer doctrine:cache:clear
 composer doctrine:migrate || exit 3

--- a/deploy/secrets_entrypoint_web.sh
+++ b/deploy/secrets_entrypoint_web.sh
@@ -18,9 +18,6 @@ if [ -n "$JWT_ID_SECRETS" ]; then
   export JWT_ID_SECRETS=$(echo "$JWT_ID_SECRETS" | base64 -d)
 fi
 
-# Make Doctrine check it's set up right, inc. using a real, persistent-across-runs cache e.g. Redis.
-composer doctrine:ensure-prod || exit 2
-
 # This is a bit hack-y because on a deploy that includes a new migration, several containers may be in
 # a race to try to run it. However because migrations are versioned and run transactionally, and we
 # call Doctrine with `--allow-no-migration`, it *should* be safe and subsequent instances' attempts to


### PR DESCRIPTION
It's gone in v3: Doctrine does not provide its own cache implementation anymore and relies on
                 the PSR-6 standard instead. As a consequence, we cannot determine anymore
                 whether a given cache adapter is suitable for a production environment.

https://github.com/doctrine/orm/blob/4262eb495b4d2a53b45de1ac58881e0091f2970f/UPGRADE.md?plain=1#L927-L935