### PR TITLE
Make only Doctrine ORM skip the migrations table, not Doctrine Migrations itself

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -99,10 +99,13 @@ return function (ContainerBuilder $containerBuilder) {
             // DBAL needs schema filter to not incorrectly include migrations table as if it's ORM managed.
             // See https://github.com/doctrine/migrations/issues/1406
             $dbalConfig = new \Doctrine\DBAL\Configuration();
-            $dbalConfig->setSchemaAssetsFilter(
-                static fn (string|AbstractAsset $assetName): bool =>
-                    (is_string($assetName) ? $assetName : $assetName->getObjectName()) !== 'doctrine_migration_versions'
-            );
+            // Only set schema assets filter for ORM schema tool commands, not for migrations
+            if (getenv('DOCTRINE_ORM_SCHEMA_TOOL')) {
+                $dbalConfig->setSchemaAssetsFilter(
+                    static fn (string|AbstractAsset $asset): bool =>
+                        (is_string($asset) ? $asset : $asset->getObjectName()) !== 'doctrine_migration_versions'
+                );
+            }
 
             return new EntityManager(
                 DriverManager::getConnection($connectionParams, $dbalConfig),

--- a/bin/doctrine
+++ b/bin/doctrine
@@ -8,6 +8,9 @@ use Doctrine\ORM\Tools\Console\ConsoleRunner;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Psr\Container\ContainerInterface;
 
+// Distinguish from Doctrine Migrations
+putenv('DOCTRINE_ORM_SCHEMA_TOOL=1');
+
 /** @var ContainerInterface $container */
 $container = require __DIR__ . '/../bootstrap.php';
 


### PR DESCRIPTION
Otherwise it will forever fail trying to recreate the versions table